### PR TITLE
elegantly handle user deactivation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -78,9 +78,10 @@ export const sendTo = (users, rawEvent, alwaysSend = false) => {
           .catch((err) => {
             if (err && (
               err.message === '403 {"ok":false,"error_code":403,"description":"Bot was blocked by the user"}'
+              || err.message === '403 {"ok":false,"error_code":403,"description":"Forbidden: use is deactivated"}'
               || err.message === '400 {"ok":false,"error_code":400,"description":"PEER_ID_INVALID"}'
             )) {
-              info('user (%o) blocked the bot, removing from the chat', user)
+              info('user (%o) blocked the bot (or deactivated), removing from the chat', user)
               delUser(user.id)
             } else {
               warn('message not sent to user (%o): %o', user, err)


### PR DESCRIPTION
instead of getting an error each time you try to send to a user when they deactivated, remove them from the chat instead