### PR TITLE
Bug fix on /stop command

### DIFF
--- a/src/commands/user/index.js
+++ b/src/commands/user/index.js
@@ -34,7 +34,7 @@ export default function userCommands (user, evt, reply) {
       break
 
     case 'stop':
-      if (!user) return reply(cursive(USER_NOT_IN_CHAT))
+      if (user.kicked) return reply(cursive(USER_NOT_IN_CHAT))
       kickUser(evt.user)
       sendToAll(htmlMessage(
         `${getUsername(user)} <i>${USER_LEFT_CHAT}</i>`


### PR DESCRIPTION
Changed ```if (!user)``` to ```if (user.kicked)``` on Line37.

Issue:
Users are kicked instead of removed from db.json when they use stop command - Allows /stop spam

Fix applied:
If /stop is spammed, active users will not receive the ```${getUsername(user)} <i>${USER_LEFT_CHAT}</i>``` message multiple times.