### PR TITLE
"Moderation Update"

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -22,7 +22,7 @@ export const getFromCache = (evt, reply) => {
 
 export const setWarnedFlag = (id) => {
   let { cacheId } = messageHistory[id]
-  messageGroups[cacheId].warned = true;
+  messageGroups[cacheId].warned = true
 }
 
 export const hasWarnedFlag = (id) => {

--- a/src/cache.js
+++ b/src/cache.js
@@ -20,6 +20,16 @@ export const getFromCache = (evt, reply) => {
   return messageRepliedTo
 }
 
+export const setWarnedFlag = (id) => {
+  let { cacheId } = messageHistory[id]
+  messageGroups[cacheId].warned = true;
+}
+
+export const hasWarnedFlag = (id) => {
+  let { cacheId } = messageHistory[id]
+  return messageGroups[cacheId].warned ? true : false
+}
+
 export const setCache = (id, cacheId, sender, receiver) => {
   // add to history
   messageHistory[id] = { sender, cacheId }

--- a/src/commands/mod/index.js
+++ b/src/commands/mod/index.js
@@ -23,7 +23,7 @@ const getReason = (evt) =>
 const ERR_NO_REPLY = 'please reply to a message to use this command'
 
 export default function modCommands (user, evt, reply) {
-  let messageRepliedTo
+  const messageRepliedTo = getFromCache(evt, reply)
   const msgId = evt && evt.raw && evt.raw.reply_to_message && evt.raw.reply_to_message.message_id
 
   switch (evt.cmd) {
@@ -35,7 +35,6 @@ export default function modCommands (user, evt, reply) {
 
     case 'info':
       if (evt && evt.raw && evt.raw.reply_to_message) {
-        messageRepliedTo = getFromCache(evt, reply)
         if (messageRepliedTo) {
           const user = getUser(messageRepliedTo.sender)
           reply(htmlMessage(
@@ -46,7 +45,6 @@ export default function modCommands (user, evt, reply) {
       break
 
     case 'delete':
-      messageRepliedTo = getFromCache(evt, reply)
       let replyCache = getCacheGroup(msgId)
 
       if (messageRepliedTo) {
@@ -67,9 +65,9 @@ export default function modCommands (user, evt, reply) {
             }
           });
           sendToUser(messageRepliedTo.sender, {
-            ...cursive(handedCooldown(formatTime(cooldownTime), true)),
+            ...cursive(handedCooldown(cooldownTime, true)),
             options: {
-              reply_to_message_id: evt && evt.raw && evt.raw.reply_to_message && evt.raw.reply_to_message.message_id,
+              reply_to_message_id: msgId,
               parse_mode: 'HTML'
             }
           })
@@ -82,16 +80,14 @@ export default function modCommands (user, evt, reply) {
       break
 
     case 'warn':
-      messageRepliedTo = getFromCache(evt, reply)
-
       if (messageRepliedTo) {
         if (!hasWarnedFlag(msgId)) {
           const cooldownTime = addWarning(messageRepliedTo.sender)
           setWarnedFlag(msgId)
           sendToUser(messageRepliedTo.sender, {
-            ...cursive(handedCooldown(formatTime(cooldownTime))),
+            ...cursive(handedCooldown(cooldownTime)),
             options: {
-              reply_to_message_id: evt && evt.raw && evt.raw.reply_to_message && evt.raw.reply_to_message.message_id,
+              reply_to_message_id: msgId,
               parse_mode: 'HTML'
             }
           })

--- a/src/commands/user/index.js
+++ b/src/commands/user/index.js
@@ -5,7 +5,7 @@ import {
   infoText, configSet, usersText,
   USER_NOT_IN_CHAT, USER_LEFT_CHAT
 } from '../../messages'
-import { kickUser, getUsers, getSystemConfig, setDebugMode } from '../../db'
+import { setLeft, getUsers, getSystemConfig, setDebugMode } from '../../db'
 import { version } from '../../../package.json'
 
 export default function userCommands (user, evt, reply) {
@@ -18,7 +18,8 @@ export default function userCommands (user, evt, reply) {
 
 <i>or reply to a message and use:</i>
   /info - to get info about the user that sent this message
-  /warn - to warn the user that sent this message`))
+  /warn - to warn the user that sent this message
+  /delete - delete a message and warn the user`))
       break
 
     case 'adminhelp':
@@ -32,11 +33,11 @@ export default function userCommands (user, evt, reply) {
       break
 
     case 'stop':
-      if (!user || user.banned) return reply(cursive(USER_NOT_IN_CHAT))
-      kickUser(evt.user)
+      if (!user || user.left) return reply(cursive(USER_NOT_IN_CHAT))
       sendToAll(htmlMessage(
         `${getUsername(user)} <i>${USER_LEFT_CHAT}</i>`
       ))
+      setLeft(user.id, true)
       break
 
     case 'users':

--- a/src/commands/user/index.js
+++ b/src/commands/user/index.js
@@ -32,7 +32,7 @@ export default function userCommands (user, evt, reply) {
       break
 
     case 'stop':
-      if (!user || user.kicked) return reply(cursive(USER_NOT_IN_CHAT))
+      if (!user || user.banned) return reply(cursive(USER_NOT_IN_CHAT))
       kickUser(evt.user)
       sendToAll(htmlMessage(
         `${getUsername(user)} <i>${USER_LEFT_CHAT}</i>`

--- a/src/commands/user/index.js
+++ b/src/commands/user/index.js
@@ -18,9 +18,7 @@ export default function userCommands (user, evt, reply) {
 
 <i>or reply to a message and use:</i>
   /info - to get info about the user that sent this message
-  /warn - to warn the user that sent this message
-  /kick - to kick the user that sent this message
-  /ban - to ban the user that sent this message`))
+  /warn - to warn the user that sent this message`))
       break
 
     case 'adminhelp':

--- a/src/constants.js
+++ b/src/constants.js
@@ -11,5 +11,5 @@ export const SCORE_LINK = 0.5  // score per message link
 export const SCORE_CHARACTER = 0.01 // score per message character
 export const SCORE_STICKER = 1.5 // score per sticker
 
-export const BASE_COOLDOWN_TIME = 5
+export const BASE_COOLDOWN_MINUTES = 5
 export const WARN_EXPIRE = 1 * WEEKS

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,4 @@
-import { SECONDS } from './time'
+import { SECONDS, MINUTES, WEEKS } from './time'
 
 export const LINK_REGEX = /(https?:\/\/)?[A-Za-z0-9-_]\.[A-Za-z]/g
 
@@ -10,3 +10,6 @@ export const SCORE_MESSAGE = 1 // score per message sent
 export const SCORE_LINK = 0.5  // score per message link
 export const SCORE_CHARACTER = 0.01 // score per message character
 export const SCORE_STICKER = 1.5 // score per sticker
+
+export const BASE_COOLDOWN_TIME = 5
+export const WARN_EXPIRE = 1 * WEEKS

--- a/src/db.js
+++ b/src/db.js
@@ -7,8 +7,8 @@ db.defaults({ users: [], system: {} }).value()
 
 export const getUser = (id) => db.get('users').find({ id }).value()
 export const getUserByUsername = (username) => db.get('users').find({ username }).value()
-export const addUser = (id) => db.get('users').push({ id, rank: 0, version }).value()
-export const rejoinUser = (id) => db.get('users').find({ id }).assign({ kicked: false, banned: false }).value()
+export const addUser = (id) => db.get('users').push({ id, rank: 0, version, left: false }).value()
+export const rejoinUser = (id) => setLeft(id, false)
 export const delUser = (id) => db.get('users').remove({ id }).value()
 export const getUsers = () => db.get('users').value()
 export const updateUser = (id, data) => db.get('users').find({ id }).assign(data).value()
@@ -31,7 +31,6 @@ export const addWarning = (id) => {
     // set the warning updated time
     db.get('users').find({ id }).assign({ warnUpdated: Date.now() }).value()
     // ban the user for a set time
-    kickUser(id)
     banUser(id, cooldownTime)
 
     return cooldownTime
@@ -47,14 +46,17 @@ export const rmWarning = (id) => {
     }
 }
 
-export const kickUser = (id) => db.get('users').find({ id }).assign({ kicked: true }).value()
+export const setLeft = (id, value) => {
+    db.get('users').find({ id }).assign({ left: value }).value()
+}
+
 export const banUser = (id, ms) =>
   db.get('users')
     .find({ id })
     .assign({ banned: Date.now() + ms })
     .value()
 
-export const isActive = (user) => user && !user.kicked && !user.banned
+export const isActive = (user) => user && !user.left
 
 export const setRank = (id, rank) => db.get('users').find({ id }).assign({ rank }).value()
 export const setDebugMode = (id, val) => db.get('users').find({ id }).assign({ debug: val }).value()

--- a/src/db.js
+++ b/src/db.js
@@ -19,18 +19,17 @@ const getUserWarnings = (id) => {
   else return user.warnings
 }
 
-import { BASE_COOLDOWN_TIME } from './constants'
+import { BASE_COOLDOWN_MINUTES } from './constants'
 import { MINUTES, HOURS } from './time'
 
 // alias to add a warning to a user
 export const addWarning = (id) => {
     let warnings = getUserWarnings(id)
-    let cooldownTime = Math.pow(BASE_COOLDOWN_TIME, warnings) * MINUTES
+    let cooldownTime = Math.pow(BASE_COOLDOWN_MINUTES, warnings) * MINUTES
+
     // increment user warnings
     db.get('users').find({ id }).assign({ warnings: warnings + 1 }).value()
-    // set the warning updated time
-    db.get('users').find({ id }).assign({ warnUpdated: Date.now() }).value()
-    // ban the user for a set time
+    updateWarnTime(id)
     banUser(id, cooldownTime)
 
     return cooldownTime
@@ -41,9 +40,12 @@ export const rmWarning = (id) => {
     let warnings = getUserWarnings(id)
     if (warnings > 0) {
         db.get('users').find({ id }).assign({ warnings: warnings - 1 }).value()
-        // set the warning updated time
-        db.get('users').find({ id }).assign({ warnUpdated: Date.now() }).value()
+        updateWarnTime(id)
     }
+}
+
+export const updateWarnTime = (id) => {
+    db.get('users').find({ id }).assign({ warnUpdated: Date.now() }).value()
 }
 
 export const setLeft = (id, value) => {

--- a/src/db.js
+++ b/src/db.js
@@ -44,9 +44,8 @@ export const rmWarning = (id) => {
     }
 }
 
-export const updateWarnTime = (id) => {
+export const updateWarnTime = (id) =>
     db.get('users').find({ id }).assign({ warnUpdated: Date.now() }).value()
-}
 
 export const setLeft = (id, value) => {
     db.get('users').find({ id }).assign({ left: value }).value()

--- a/src/messages.js
+++ b/src/messages.js
@@ -1,12 +1,14 @@
+import { WARN_EXPIRE } from './constants'
 import { getRank } from './ranks'
 import { DAYS } from './time'
 
 export const USER_NOT_IN_CHAT = 'you\'re not in the chat yet! Use </i>/start<i> to join'
 export const USER_IN_CHAT = 'you\'re already in the chat!'
-export const USER_BANNED_FROM_CHAT = 'you\'re banned from this chat'
+export const USER_BANNED_FROM_CHAT = 'your cooldown expires at'
 export const USER_LEFT_CHAT = 'left the chat'
 export const USER_JOINED_CHAT = 'joined the chat'
 export const USER_SPAMMING = 'your recent messages have been deemed spammy, if this is a false positive contact @omnidan or @hdrive'
+export const ALREADY_WARNED = 'a warning has already been issued for this message'
 
 const parseValue = (val) => {
   if (typeof val === 'boolean') return val ? 'on' : 'off'
@@ -73,11 +75,10 @@ export const usersText = (users) =>
 export const infoText = (user) => !user ? '<i>user not found</i>' :
   `<b>id:</b> ${obfuscateId(user.id)}, <b>username:</b> @${user.username}, ` +
   `<b>rank:</b> ${user.rank} (${getRank(user.rank)}), ` +
-  `<b>warnings:</b> ${user.warnings || 0} ${generateSmiley(user.warnings)}, ` +
+  `<b>warnings:</b> ${user.warnings || 0} ${generateSmiley(user.warnings)}${ user.warnings > 0 ? ` (one warning will be removed on ${stringifyTimestamp(user.warnUpdated + WARN_EXPIRE)})` : ''}, ` +
   `<b>kicked:</b> ${user.kicked ? 'yes' : 'no'}, <b>banned:</b> ${user.banned ? stringifyTimestamp(user.banned) : 'no'}`
 
 export const modInfoText = (user) => !user ? '<i>user not found</i>' :
-  `<b>id:</b> ${obfuscateId(user.id)}, <b>username:</b> anon, ` +
-  `<b>rank:</b> ???, ` +
-  `<b>warnings:</b> ${user.warnings || 0} ${generateSmiley(user.warnings)}, ` +
+  `<b>id:</b> ${obfuscateId(user.id)}, <b>username:</b> anonymous, ` +
+  `<b>rank:</b> n/a, ` +
   `<b>kicked:</b> ${user.kicked ? 'yes' : 'no'}, <b>banned:</b> ${user.banned ? stringifyTimestamp(user.banned) : 'no'}`

--- a/src/messages.js
+++ b/src/messages.js
@@ -70,15 +70,15 @@ export const stringifyTimestamp = (ts) =>
   (new Date(ts)).toUTCString()
 
 export const usersText = (users) =>
-  `<b>${users.length}</b> <i>users:</i> ` + users.map(getUsername).join(', ')
+  `<b>${users.filter(u => !u.left).length}</b> <i>users:</i> ` + users.filter(u => !u.left).map(getUsername).join(', ')
 
 export const infoText = (user) => !user ? '<i>user not found</i>' :
   `<b>id:</b> ${obfuscateId(user.id)}, <b>username:</b> @${user.username}, ` +
   `<b>rank:</b> ${user.rank} (${getRank(user.rank)}), ` +
   `<b>warnings:</b> ${user.warnings || 0} ${generateSmiley(user.warnings)}${ user.warnings > 0 ? ` (one warning will be removed on ${stringifyTimestamp(user.warnUpdated + WARN_EXPIRE)})` : ''}, ` +
-  `<b>cooldown:</b> ${user.banned ? 'yes, until ' + stringifyTimestamp(user.banned) : 'no'}`
+  `<b>cooldown:</b> ${user.banned >= Date.now() ? 'yes, until ' + stringifyTimestamp(user.banned) : 'no'}`
 
 export const modInfoText = (user) => !user ? '<i>user not found</i>' :
   `<b>id:</b> ${obfuscateId(user.id)}, <b>username:</b> anonymous, ` +
   `<b>rank:</b> n/a, ` +
-  `<b>cooldown:</b> ${user.banned ? 'yes, until ' + stringifyTimestamp(user.banned) : 'no'}`
+  `<b>cooldown:</b> ${user.banned >= Date.now() ? 'yes, until ' + stringifyTimestamp(user.banned) : 'no'}`

--- a/src/messages.js
+++ b/src/messages.js
@@ -76,9 +76,9 @@ export const infoText = (user) => !user ? '<i>user not found</i>' :
   `<b>id:</b> ${obfuscateId(user.id)}, <b>username:</b> @${user.username}, ` +
   `<b>rank:</b> ${user.rank} (${getRank(user.rank)}), ` +
   `<b>warnings:</b> ${user.warnings || 0} ${generateSmiley(user.warnings)}${ user.warnings > 0 ? ` (one warning will be removed on ${stringifyTimestamp(user.warnUpdated + WARN_EXPIRE)})` : ''}, ` +
-  `<b>banned:</b> ${user.banned ? 'yes, until ' + stringifyTimestamp(user.banned) : 'no'}`
+  `<b>cooldown:</b> ${user.banned ? 'yes, until ' + stringifyTimestamp(user.banned) : 'no'}`
 
 export const modInfoText = (user) => !user ? '<i>user not found</i>' :
   `<b>id:</b> ${obfuscateId(user.id)}, <b>username:</b> anonymous, ` +
   `<b>rank:</b> n/a, ` +
-  `<b>banned:</b> ${user.banned ? 'yes, until ' + stringifyTimestamp(user.banned) : 'no'}`
+  `<b>cooldown:</b> ${user.banned ? 'yes, until ' + stringifyTimestamp(user.banned) : 'no'}`

--- a/src/messages.js
+++ b/src/messages.js
@@ -9,6 +9,10 @@ export const USER_LEFT_CHAT = 'left the chat'
 export const USER_JOINED_CHAT = 'joined the chat'
 export const USER_SPAMMING = 'your recent messages have been deemed spammy, if this is a false positive contact @omnidan or @hdrive'
 export const ALREADY_WARNED = 'a warning has already been issued for this message'
+export const MESSAGE_DISAPPEARED = 'this message disappeared into the ether'
+
+export const handedCooldown = (duration, deleted = false) =>
+  `you've been handed a cooldown of ${duration} for this message ${deleted ? '(message also deleted)' : ''}`
 
 const parseValue = (val) => {
   if (typeof val === 'boolean') return val ? 'on' : 'off'
@@ -69,8 +73,10 @@ export const getUsernameFromEvent = (evt) => {
 export const stringifyTimestamp = (ts) =>
   (new Date(ts)).toUTCString()
 
-export const usersText = (users) =>
-  `<b>${users.filter(u => !u.left).length}</b> <i>users:</i> ` + users.filter(u => !u.left).map(getUsername).join(', ')
+export const usersText = (users) => {
+  let u = users.filter(isActive)
+  `<b>${u.length}</b> <i>users:</i> ` + u.map(getUsername).join(', ')
+}
 
 export const infoText = (user) => !user ? '<i>user not found</i>' :
   `<b>id:</b> ${obfuscateId(user.id)}, <b>username:</b> @${user.username}, ` +

--- a/src/messages.js
+++ b/src/messages.js
@@ -76,9 +76,9 @@ export const infoText = (user) => !user ? '<i>user not found</i>' :
   `<b>id:</b> ${obfuscateId(user.id)}, <b>username:</b> @${user.username}, ` +
   `<b>rank:</b> ${user.rank} (${getRank(user.rank)}), ` +
   `<b>warnings:</b> ${user.warnings || 0} ${generateSmiley(user.warnings)}${ user.warnings > 0 ? ` (one warning will be removed on ${stringifyTimestamp(user.warnUpdated + WARN_EXPIRE)})` : ''}, ` +
-  `<b>kicked:</b> ${user.kicked ? 'yes' : 'no'}, <b>banned:</b> ${user.banned ? stringifyTimestamp(user.banned) : 'no'}`
+  `<b>banned:</b> ${user.banned ? 'yes, until ' + stringifyTimestamp(user.banned) : 'no'}`
 
 export const modInfoText = (user) => !user ? '<i>user not found</i>' :
   `<b>id:</b> ${obfuscateId(user.id)}, <b>username:</b> anonymous, ` +
   `<b>rank:</b> n/a, ` +
-  `<b>kicked:</b> ${user.kicked ? 'yes' : 'no'}, <b>banned:</b> ${user.banned ? stringifyTimestamp(user.banned) : 'no'}`
+  `<b>banned:</b> ${user.banned ? 'yes, until ' + stringifyTimestamp(user.banned) : 'no'}`

--- a/src/messages.js
+++ b/src/messages.js
@@ -1,6 +1,6 @@
 import { WARN_EXPIRE } from './constants'
 import { getRank } from './ranks'
-import { DAYS } from './time'
+import { DAYS, formatTime } from './time'
 
 export const USER_NOT_IN_CHAT = 'you\'re not in the chat yet! Use </i>/start<i> to join'
 export const USER_IN_CHAT = 'you\'re already in the chat!'
@@ -12,7 +12,7 @@ export const ALREADY_WARNED = 'a warning has already been issued for this messag
 export const MESSAGE_DISAPPEARED = 'this message disappeared into the ether'
 
 export const handedCooldown = (duration, deleted = false) =>
-  `you've been handed a cooldown of ${duration} for this message ${deleted ? '(message also deleted)' : ''}`
+  `you've been handed a cooldown of ${formatTime(duration)} for this message ${deleted ? '(message also deleted)' : ''}`
 
 const parseValue = (val) => {
   if (typeof val === 'boolean') return val ? 'on' : 'off'

--- a/src/time.js
+++ b/src/time.js
@@ -15,6 +15,6 @@ export const formatTime = (ms) => {
         return Math.ceil(ms / DAYS) + 'd'
     } else {
         // let's really hope this never happens, eh?
-        return Math.ceil(ms / HOURS) + 'w'
+        return Math.ceil(ms / WEEKS) + 'w'
     }
 }

--- a/src/time.js
+++ b/src/time.js
@@ -2,3 +2,19 @@ export const SECONDS = 1000
 export const MINUTES = 60 * SECONDS
 export const HOURS = 60 * MINUTES
 export const DAYS = 24 * HOURS
+export const WEEKS = 7 * DAYS
+
+export const formatTime = (ms) => {
+    if (ms < MINUTES) {
+        return Math.ceil(ms / SECONDS) + 's'
+    } else if (ms < HOURS) {
+        return Math.ceil(ms / MINUTES) + 'm'
+    } else if (ms < DAYS) {
+        return Math.ceil(ms / HOURS) + 'h'
+    } else if (ms < WEEKS) {
+        return Math.ceil(ms / DAYS) + 'd'
+    } else {
+        // let's really hope this never happens, eh?
+        return Math.ceil(ms / HOURS) + 'w'
+    }
+}


### PR DESCRIPTION
 - [x] don't show a message when someone rejoins (only on first join)
 - [x] remove `/kick` and `/ban` commands for moderators
 - [x] remove the concept of banning and a concept of a 'cooldown': you can still see messages, but not post any
 - [x] warning a user now hands them a cooldown based on their warning count
 - [x] deleting a message also hands the user a cooldown
 - [x] kicking is completely removed - /info won't show this information
 - [x] warnings now expire after a while (check `/info`)
 - [x] `/info` won't show warnings for anyone but yourself
 - [x] `/info` shows the next time you'll have a warning removed
 - [x] moderator actions aren't relayed to other moderators or logged in console
 - [x] messages can only be warned once by any one person